### PR TITLE
Add IPC refactoring framework docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ To begin with Agent Zero, follow the links below for detailed guides on various 
 - **[Installation](installation.md):** Set up (or [update](installation.md#how-to-update-agent-zero)) Agent Zero on your system.
 - **[Usage Guide](usage.md):** Explore GUI features and usage scenarios.
 - **[Architecture Overview](architecture.md):** Understand the internal workings of the framework.
+- **[IPC Refactoring Framework](ipc_refactoring_framework.md):** Overview of the native gRPC communication layer.
 - **[Contributing](contribution.md):** Learn how to contribute to the Agent Zero project.
 - **[Troubleshooting and FAQ](troubleshooting.md):** Find answers to common issues and questions.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,7 +9,7 @@ This simplified diagram illustrates the hierarchical relationship between agents
 The user or Agent 0 is at the top of the hierarchy, delegating tasks to subordinate agents, which can further delegate to other agents. Each agent can utilize tools and access the shared assets (prompts, memory, knowledge, extensions and instruments) to perform its tasks.
 
 ## Runtime Architecture
-Agent Zero's runtime architecture is built around Docker containers:
+Agent Zero's original runtime relied entirely on Docker containers:
 
 1. **Host System (your machine)**:
    - Requires only Docker and a web browser
@@ -21,6 +21,12 @@ Agent Zero's runtime architecture is built around Docker containers:
    - Manages the Web UI and API endpoints
    - Handles all core functionalities including code execution
    - Provides a standardized environment across all platforms
+
+With the native IPC refactor, the framework can also run directly on Ubuntu.
+In this mode a gRPC server replaces the Docker RFC mechanism, enabling faster
+startup and easier development without containers. See
+[IPC Refactoring Framework](ipc_refactoring_framework.md) for an overview of the
+migration strategy.
 
 This architecture ensures:
 - Consistent environment across platforms

--- a/docs/ipc_refactoring_framework.md
+++ b/docs/ipc_refactoring_framework.md
@@ -1,0 +1,35 @@
+# IPC Refactoring Framework
+
+This document outlines a strategy for modernising Agent Zero's inter-process communication so it can run natively on Ubuntu without the legacy Docker based system.
+
+## Why Replace the Legacy IPC?
+- Custom IPC code has grown brittle and platform specific.
+- Security features such as TLS are missing.
+- Lack of a formal contract makes new development risky and error prone.
+
+A modern IPC layer must be maintainable, scalable, performant and secure.
+
+## gRPC vs ZeroMQ
+| Feature | gRPC | ZeroMQ |
+|---|---|---|
+|Abstraction|High level RPC framework|Low level messaging library|
+|Transport|HTTP/2|Custom TCP patterns|
+|Serialization|Protocol Buffers|User defined|
+|Security|Built in TLS|External libraries required|
+|Load balancing|Native client support|Manual implementation|
+
+Although ZeroMQ can be faster in synthetic benchmarks, gRPC's batteries‑included approach provides a better long term foundation and forces a clear contract via Protocol Buffers. Therefore gRPC is the recommended solution for Agent Zero.
+
+## Migration Methodology (PIMF)
+1. **Prepare** – map all existing IPC calls and create characterization tests. Introduce an adapter interface and dependency injection so that the old IPC can be swapped with minimal code changes.
+2. **Implement** – build the gRPC stack. Define services in `.proto` files and generate the Python stubs. Create gRPC based adapters that implement the IPC interface.
+3. **Migrate** – activate the new system gradually using a feature flag. Roll out in stages (CI, staging, canary, phased production) while monitoring metrics.
+4. **Finalize** – once gRPC handles 100% of traffic, remove the legacy IPC code and update documentation.
+
+## Operational Notes
+- Use `asyncio` with grpcio's asynchronous API for high concurrency.
+- Map internal errors to gRPC status codes and implement retries with backoff for transient failures.
+- Enable TLS for service to service communication and propagate authentication data via metadata.
+- In CI, lint `.proto` files and generate stubs as part of the build.
+
+Following this framework will lead to a more robust, maintainable and secure communication layer for Agent Zero.


### PR DESCRIPTION
## Summary
- document the new IPC refactoring approach and gRPC migration
- mention the native IPC architecture in the architecture overview
- link to the new document from the docs README

## Testing
- `python python/helpers/test_grpc_phase2.py`

------
https://chatgpt.com/codex/tasks/task_e_68835a140b9c83269ad33a05b5e024b5