### PR TITLE
Add Flagsmith-based feature flag client

### DIFF
--- a/python/helpers/feature_flag_client.py
+++ b/python/helpers/feature_flag_client.py
@@ -1,0 +1,39 @@
+import os
+from typing import Optional
+
+try:
+    from flagsmith import Flagsmith
+except ImportError:  # flagsmith may not be installed
+    Flagsmith = None  # type: ignore
+
+
+class FeatureFlagClient:
+    """Simple wrapper for retrieving feature flags via Flagsmith."""
+
+    _client: Optional["Flagsmith"] = None
+    _initialized: bool = False
+
+    @classmethod
+    def _init_client(cls) -> None:
+        if cls._initialized:
+            return
+        env_key = os.getenv("FLAGSMITH_ENVIRONMENT_KEY")
+        if env_key and Flagsmith:
+            api_url = os.getenv("FLAGSMITH_API_URL", "https://edge.flagsmith.com/api/v1/")
+            try:
+                cls._client = Flagsmith(environment_key=env_key, api_url=api_url)
+            except Exception:
+                cls._client = None
+        cls._initialized = True
+
+    @classmethod
+    def is_feature_enabled(cls, name: str, default: Optional[bool] = None) -> Optional[bool]:
+        """Return the state of a feature flag if available."""
+        cls._init_client()
+        if cls._client:
+            try:
+                flags = cls._client.get_environment_flags()
+                return bool(flags.is_feature_enabled(name))
+            except Exception:
+                pass
+        return default

--- a/python/helpers/feature_flags.py
+++ b/python/helpers/feature_flags.py
@@ -1,5 +1,7 @@
 import os
-from typing import Dict, Any
+from typing import Dict, Any, Optional
+
+from .feature_flag_client import FeatureFlagClient
 
 class FeatureFlags:
     """Centralized feature flag management for Agent Zero"""
@@ -12,6 +14,9 @@ class FeatureFlags:
     @staticmethod
     def use_grpc_ipc() -> bool:
         """Check if gRPC IPC should be used instead of RFC"""
+        remote = FeatureFlagClient.is_feature_enabled("use-grpc-ipc")
+        if remote is not None:
+            return remote
         return os.environ.get('AGENT_ZERO_USE_GRPC', 'false').lower() == 'true'
     
     @staticmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ fastmcp==2.3.4
 flask[async]==3.0.3
 flask-basicauth==0.2.0
 flaredantic==0.1.4
+flagsmith==3.9.2
 GitPython==3.1.43
 inputimeout==1.0.4
 kokoro>=0.9.2


### PR DESCRIPTION
## Summary
- add a simple Flagsmith feature flag client
- allow `use_grpc_ipc` flag to consult remote feature flag service
- include `flagsmith` in requirements

## Testing
- `python python/helpers/test_grpc_phase2.py`

------
https://chatgpt.com/codex/tasks/task_e_68835a1c4f808326ac516c7e1f946768