### PR TITLE
Fix async tests and disable LFS for mp4

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # Auto detect text files and perform LF normalization
 * text=auto eol=lf
 *.zip filter=lfs diff=lfs merge=lfs -text
-*.mp4 filter=lfs diff=lfs merge=lfs -text
+# Disable LFS for mp4 files to avoid pointer issues in tests
+*.mp4 -filter -diff -merge -text

--- a/python/helpers/test_grpc_phase2.py
+++ b/python/helpers/test_grpc_phase2.py
@@ -9,6 +9,7 @@ import os
 import sys
 import time
 from pathlib import Path
+import pytest
 
 # Add the project root to the path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
@@ -24,6 +25,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+@pytest.mark.asyncio
 async def test_grpc_server():
     """Test the gRPC server functionality"""
     logger.info("=== Testing gRPC Server ===")
@@ -123,6 +125,7 @@ def test_feature_flags():
     
     logger.info("Feature flags tests passed")
 
+@pytest.mark.asyncio
 async def test_grpc_client():
     """Test gRPC client functionality"""
     logger.info("=== Testing gRPC Client ===")

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ crontab==1.0.1
 pathspec>=0.12.1
 psutil>=7.0.0
 soundfile==0.13.1
+pytest-asyncio==0.23.5


### PR DESCRIPTION
## Summary
- mark async tests with pytest-asyncio
- add pytest-asyncio dependency
- disable git LFS for mp4 files to avoid pointer issues

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688358cb08208326b69e4476388f409b