### PR TITLE
Fix tests imports and async markers

### DIFF
--- a/python/api/backup_test.py
+++ b/python/api/backup_test.py
@@ -1,3 +1,10 @@
+from pathlib import Path
+import sys
+
+# Ensure the project root is on the import path so that "python" package can be
+# resolved correctly when running tests directly via ``pytest``.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
 from python.helpers.api import ApiHandler, Request, Response
 from python.helpers.backup import BackupService
 

--- a/python/helpers/test_grpc_phase2.py
+++ b/python/helpers/test_grpc_phase2.py
@@ -5,6 +5,7 @@ Test script for Agent Zero Phase 2 gRPC implementation
 
 import asyncio
 import logging
+import pytest
 import os
 import sys
 import time
@@ -24,6 +25,7 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+@pytest.mark.asyncio
 async def test_grpc_server():
     """Test the gRPC server functionality"""
     logger.info("=== Testing gRPC Server ===")
@@ -123,6 +125,7 @@ def test_feature_flags():
     
     logger.info("Feature flags tests passed")
 
+@pytest.mark.asyncio
 async def test_grpc_client():
     """Test gRPC client functionality"""
     logger.info("=== Testing gRPC Client ===")


### PR DESCRIPTION
## Summary
- ensure backup_test can import project modules by adding repository root to `sys.path`
- mark async tests in `test_grpc_phase2` so pytest-asyncio runs them

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688358c9d330832696a8108223d60091