### PR TITLE
Configure pytest test discovery to ignore API modules

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests


### PR DESCRIPTION
## Summary
- limit pytest test discovery to the dedicated `tests` directory to avoid importing the `python/api` modules during test runs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895e8198a048326bdd2e807bf5b5a60